### PR TITLE
Remove unused import in lights.proto

### DIFF
--- a/lights.proto
+++ b/lights.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package teamspatzenhirn;
 
-import "util.proto";
-
 message IndicatorRepetitionCount {
   int32 count = 1;
 }


### PR DESCRIPTION
fix protoc warning `lights.proto: warning: Import util.proto but not used.`